### PR TITLE
Add provably robust boosted trees from NeurIPS2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ A curated list of gradient and adaptive boosting papers with implementations fro
 Similar collections about [graph classification](https://github.com/benedekrozemberczki/awesome-graph-classification), [classification/regression tree](https://github.com/benedekrozemberczki/awesome-decision-tree-papers) and [community detection](https://github.com/benedekrozemberczki/awesome-community-detection) papers with implementations.
 
 ## 2019
-
+- **Provably Robust Boosted Decision Stumps and Trees against Adversarial Attacks (NeurIPS 2019)**
+  - Maksym Andriushchenko, Matthias Hein
+  - [[Paper]](https://arxiv.org/abs/1906.03526)
+  - [[Code]](https://github.com/max-andr/provably-robust-boosting)
+  
 - **Induction of Non-Monotonic Logic Programs to Explain Boosted Tree Models Using LIME (AAAI 2019)**
   - Farhad Shakerin, Gopal Gupta
   - [[Paper]](https://arxiv.org/abs/1808.00629)


### PR DESCRIPTION
Hi,

We have a paper on how to train provably robust boosted decision trees at NeurIPS 2019. I think it's very relevant to this list.

Thanks,
Maksym